### PR TITLE
[DEVEDSB-98] Fix package error from error handler

### DIFF
--- a/src/main/java/com/twilio/androidsms/controllers/ErrorController.java
+++ b/src/main/java/com/twilio/androidsms/controllers/ErrorController.java
@@ -1,5 +1,3 @@
-package com.twilio.sampletemplatespring;
-
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;


### PR DESCRIPTION
Error handler doesn't need package specification in error handler, if it is specified it will break the default spring error handler.